### PR TITLE
Allow the user search for a particular device by ID

### DIFF
--- a/samples/DMDashboard/MainWindow.xaml
+++ b/samples/DMDashboard/MainWindow.xaml
@@ -7,7 +7,8 @@
         xmlns:storage="clr-namespace:DMDashboard.StorageManagement"
         xmlns:DeviceHealthAttestation="clr-namespace:DMDashboard.DeviceHealthAttestation"
         mc:Ignorable="d"
-        Title="MainWindow" Height="700" Width="1400">
+        Title="MainWindow" Height="700" Width="1400"
+        x:Name="ThisWindow">
     <Window.Resources>
         <ResourceDictionary>
             <local:BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter"/>
@@ -57,12 +58,23 @@
             <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" FontSize="16" FontWeight="Bold" Text="DM Dashboard" />
             <Grid Grid.Row="1" Grid.Column="0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Grid.Column="0" Margin="3" Text="Connection String"/>
-                <TextBox Grid.Row="0" Grid.Column="1" Margin="3" x:Name="ConnectionStringBox">
+                <TextBox   Grid.Row="0" Grid.Column="1" Margin="3" x:Name="ConnectionStringBox">
                     <TextBox.Text>&lt;enter connection string&gt;</TextBox.Text>
+                </TextBox>
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Device ID" />
+                <TextBox   Grid.Row="1"
+                           Grid.Column="1"
+                           Margin="3"
+                           Text="{Binding DeviceIdToPopulate, ElementName=ThisWindow}"
+                           x:Name="DeviceIdTextBox">
                 </TextBox>
             </Grid>
             <Button Grid.Row="2" Grid.Column="2" Margin="3" Content="List Devices" Click="OnListDevices" Width="200" HorizontalAlignment="Left"/>

--- a/samples/DMDashboard/MainWindow.xaml.cs
+++ b/samples/DMDashboard/MainWindow.xaml.cs
@@ -42,6 +42,11 @@ namespace DMDashboard
         const string IotHubConnectionString = "IotHubConnectionString";
         const string StorageConnectionString = "StorageConnectionString";
 
+        private const int NumberOfDevicesToPopulate = 100;
+        private const string DeviceIdHintText = "<if looking for a single device, enter it's ID>";
+
+        public string DeviceIdToPopulate { get; set; } = DeviceIdHintText;
+
         Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
 
         public MainWindow()
@@ -99,7 +104,17 @@ namespace DMDashboard
             DeviceListBox.ItemsSource = null;
 
             // Populate devices.
-            IEnumerable<Device> devices = await registryManager.GetDevicesAsync(100);
+            IEnumerable<Device> devices;
+            if (DeviceIdToPopulate != DeviceIdHintText && !string.IsNullOrWhiteSpace(DeviceIdToPopulate))
+            {
+                devices = new List<Device> { await registryManager.GetDeviceAsync(DeviceIdToPopulate) };
+            }
+            else
+            {
+                devices = await registryManager.GetDevicesAsync(NumberOfDevicesToPopulate);
+            }
+
+            
             List<string> deviceIds = new List<string>();
             foreach (var device in devices)
             {


### PR DESCRIPTION
This addresses a situation where there are many thousands of devices in
a particular IoT Hub, and the one that the user is looking for is not
populated by the tool by deffault.

Even if the user's device was populated amongst the thousands, this
experience is much simpler.