### PR TITLE
Added auto restart to DMSetup.cmd

### DIFF
--- a/docs/oem-device-setup.md
+++ b/docs/oem-device-setup.md
@@ -40,6 +40,7 @@ will allow you to further secure this channel.  More information about Custom Ca
 <pre>
     c:\windows\system32\systemconfigurator.exe -install
     c:\windows\system32\sc.exe config systemconfigurator start=auto
+	c:\windows\system32\sc.exe failure systemconfigurator reset= 0 actions= restart/0/restart/0/restart/0
     net start systemconfigurator
 </pre>
 

--- a/src/IoTDMClientLib/Utils.cs
+++ b/src/IoTDMClientLib/Utils.cs
@@ -174,6 +174,16 @@ namespace Microsoft.Devices.Management
 
     public class Logger
     {
+        /// <summary>
+        /// Custom log function, used alongside <see cref="LoggingChannel"/>. 
+        /// 
+        /// <see cref="Debug.WriteLine"/>is used if this is not set. 
+        /// </summary>
+        public static Action<string, LoggingLevel> CustomLog { get; set; }
+
+        /// <summary>
+        /// Logs to <see cref="Constants.ETWChannelName"/> and either to <see cref="Debug.WriteLine"/> or <see cref="CustomLog"/>
+        /// </summary>
         public static void Log(string message, LoggingLevel level)
         {
             /*
@@ -193,8 +203,16 @@ namespace Microsoft.Devices.Management
 
             using (var channel = new LoggingChannel(Constants.ETWChannelName, null /*default options*/, new Guid(Constants.ETWGuid)))
             {
-                Debug.WriteLine("[" + Constants.ETWChannelName + "]    [" + level.ToString() + "]    " + message);
                 channel.LogMessage(message, level);
+            }
+
+            if (CustomLog != null)
+            {
+                CustomLog(message, level);
+            }
+            else
+            {
+                Debug.WriteLine("[" + Constants.ETWChannelName + "]    [" + level.ToString() + "]    " + message);
             }
         }
     }


### PR DESCRIPTION
When sending and app update request (using Device Twin and DM Dashboard) an exception in SystemConfigurator service can be triggered and it stops the service which in a field scenario is less than ideal. 

An essential service like SystemConfigurator needs to be setup to be automatically started on failure. 
