### PR TITLE
 Updated OEM Device Setup with 'sc failure' and link to the example AzureDM.Services.wm.xml

### DIFF
--- a/docs/oem-device-setup.md
+++ b/docs/oem-device-setup.md
@@ -40,6 +40,7 @@ will allow you to further secure this channel.  More information about Custom Ca
 <pre>
     c:\windows\system32\systemconfigurator.exe -install
     c:\windows\system32\sc.exe config systemconfigurator start=auto
+	c:\windows\system32\sc.exe failure systemconfigurator reset= 0 actions= restart/0/restart/0/restart/0
     net start systemconfigurator
 </pre>
 

--- a/docs/oem-device-setup.md
+++ b/docs/oem-device-setup.md
@@ -35,6 +35,8 @@ will allow you to further secure this channel.  More information about Custom Ca
 
 - To configure the `SystemConfigurator` service, create a cmd file and invoke it from the main configuration script `OEMCustomization.cmd` (which is called on every boot).
 
+- Please also see example [AzureDM.Services.wm.xml](https://github.com/ms-iot/iot-adk-addonkit/blob/master/Source-arm/Packages/AzureDM.Services/AzureDM.Services.wm.xml) and [Create Windows Universal OEM Packages](https://docs.microsoft.com/en-us/windows-hardware/manufacture/iot/create-packages)
+
 #### DMSetup.cmd
 
 <pre>


### PR DESCRIPTION
When sending and app update request (using Device Twin and DM Dashboard) an exception in SystemConfigurator service can be triggered and it stops the service which in a field scenario is less than ideal.

An essential service like SystemConfigurator needs to be setup to be automatically started on failure.

Example of error that stops the Service:
_Exception: The current user has already installed an unpackaged version of this app. A packaged version cannot replace this. The conflicting package is IoTToasterSample and it was published by (...)_