### PR TITLE
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync logs methodName

### DIFF
--- a/src/IoTDMClientLib/AzureIoTHubDeviceTwinProxy.cs
+++ b/src/IoTDMClientLib/AzureIoTHubDeviceTwinProxy.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Devices.Management
 
         async Task IDeviceTwin.SetMethodHandlerAsync(string methodName, Func<string, Task<string>> methodHandler)
         {
-            Logger.Log("AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync", LoggingLevel.Information);
+            Logger.Log($"AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: {methodName}", LoggingLevel.Information);
 
             try
             {


### PR DESCRIPTION
Added 'methodName' to AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync to show better info about what's being set up.

In my testing the output now is:
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.reportAllAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.deviceHealthAttestationGetReport
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.deviceHealthAttestationReportNow
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.startFactoryResetAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.startRemoteWipeAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.startUsoClientCmdAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.getWifiDetails
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.manageAppLifeCycleAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.enumDMFolders
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.enumDMFiles
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.deleteDMFile
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.uploadDMFile
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.rebootAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.startDmAppStoreUpdateAsync
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.getCertificateDetails
AzureIoTHubDeviceTwinProxy.SetMethodHandlerAsync: windows.clearReportedPropertiesAsync